### PR TITLE
update faq.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
 <header>
   <h1>
     <img src="/assets/images/blixt-wallet-icon.png" class="blixt-wallet-header-icon" />
-    Blixt Wallet
+    <a href="/">Blixt Wallet</a>
   </h1>
   <a href="https://play.google.com/store/apps/details?id=com.blixtwallet">
     <picture>
@@ -32,14 +32,15 @@
     </picture>
   </a>
   <nav>
+    <a href="/faq">
+      <button>FAQ</button>
+    </a>
     <a href="https://features.etleneum.com/blixt">
       <button>Request a feature</button>
     </a>
   </nav>
 </header>
-<article>
 {{ content }}
-</article>
 </main>
 <script>
 const setThemeSwitcherEmoji = () => {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -139,6 +139,11 @@ header > h1 {
   font-size: 43px;
   cursor: default;
 
+  > a {
+    text-decoration: none;
+    color: var(--text-color);
+  }
+
   > .blixt-wallet-header-icon {
     width: 45px;
     margin-top: 2px;
@@ -262,4 +267,18 @@ sub {
 
 sup {
   top: -0.5em;
+}
+
+h1 {
+  font-size: 34px;
+}
+
+h2 {
+  font-size: 25px;
+}
+
+.faq {
+  > section {
+    margin-bottom: 37px;
+  }
 }

--- a/faq.html
+++ b/faq.html
@@ -5,24 +5,66 @@ title: Frequently Asked Questions
 <article class="faq">
   <h1>Frequently Asked Questions</h1>
 
+  <section id="blixt-receive-funds">
+    <h2>How do I receive funds (satoshis) into Blixt wallet?</h2>
+    <p>This is an amazing simple experience to receive funds directly in your fresh open Blixt node wallet, no need to deposit funds and manually open channels with specific nodes.</p>
+		<ol>
+		<li>Once you create the wallet and save the seed, go to Blixt settings and activate "Dunder LSP"</li>
+		<li>Go back to Blixt main screen - click on receive, put the amount, but no more than 400k sats (there's a limitation for now).</li>
+		<li>It will create a LN invoice to be paid from another LN wallet.</li>
+		<li>Once the LN invoice is paid, Dunder LSP service will create a channel of max 400k sats and push those funds you sent (200k sats for example) on your channel side. So you will have a nice channel ready to send 200k sats and receive 200k sats.</li>
+		<li>If you will have another receiving payment to your Blixt, for less than 200k sats, it will be used the same channel. If the ampount will be higher, Dunder will create a new channel (of max 400k sats). and so on with all your receiving payments.</li>
+		</ol>
+	<h3>IMPORTANT NOTE: get used to make backups of your LN channels every time you open/close a channel. Takes exactly few seconds to do it, even if for short time you store it on your own mobile memory. Later you can move it to your safe place storage. Also you can use Google Drive backup offered into Blixt. Don't be lazy and ignore this simple rule, it will save you later from much trouble.</h3>
+  </section>
+
   <section id="connect-full-node">
-    <h2>How do I connect Blixt Wallet to my own full node?</h2>
-    <p>Here follows pedagogic explanation from Darthcoin because my answer would just be "it's very simple".</p>
+    <h2>How do I connect Blixt Wallet to my own full node (BIP157)?</h2>
     <p>One thing to note is that Blixt does not yet support <a href="https://github.com/lightningnetwork/lnd/issues/4973">Tor onion v3</a>.</p>
+	<p>So for the moment, only if your home node is "visible" on clearnet (IP/domain) and have activated the SPV filters in bitcoin.conf. You can test it also using your node local IP when you connect your Blixt on the same LAN ((Wifi) as your home node.</p>
   </section>
 
-  <section>
-    <h2>How do I remotely control an Umbrel?</h2>
+  <section id="umbrel-control">
+    <h2>How do I remotely control an Umbrel node?</h2>
     <p><strong>Blixt Wallet</strong> is a fully fledged lightning node in of itself. Rather than controlling your full node at your home, enable to Tor and open a channel towards it.</p>
+	<p>Blixt node can be a really good "companion" for your home Umbrel node. Take this example:</p>
+		<ul>
+		<li>you have your Umbrel LN node with lots of channels open and do several routing. That's your main "bank" withg a lot of funds in it. Umbrel is your routing node.</li>
+		<li>you have Blixt in your mobile phone, that can be your "node companion", with smaller amounts of satoshis. Blixt is your "spending" node, that need fast and cheap paths for quick spending. So connecting it with your Umbrel node, by opening a channel with it, you can move easy funds and use your Umbrel node as "frontend" sender.</li>
+		<li>your Blixt mobile node also can connect to other nodes and Dunder LSP. That will bring you even more connectivity and options to move funds around, in a very easy and quick manner.</li>
+		<li>you can have a Dunder LSP channel for incoming txs and a normal private channel with your home/Umbrel node for outgoing txs.</li>
+		</ul>
   </section>
 
-  <section>
-    <h2>How do I do this?</h2>
-    <p>Some text explaining how to do that</p>
+  <section id="umbrel-channel">
+    <h2>How do I open a channel with my Umbrel/myNode/Raspiblitz/other node?</h2>
+    <p>There are 2 options: opening from Blixt towards your node also from your node towards your Blixt node.</p>
+	<p>But first let's mention some aspects to be taken in consideration:</p>
+		<ul>
+		<li>these channels open with your home node, will be private by default. That means you will not be able to route other txs through them. And are private for a reason: a mobile node is not supposed to be 100% all the time online, only when is needed to make a tx by the user.</li>
+		<li>usually these channels are open using <a href="https://en.wikipedia.org/wiki/Tor_(network)">Tor network</a>, due to the fact that most of home nodes (Umbrel, myNode, Raspiblitz) are by default Tor enabled. So when you want to open/use these channels, be sure you activate Tor on your Blixt app.</li>
+		<li>these channels are your first hop into a payment, so you can easily set 0 total fees and let your main home node to deal with the best following route.</li>
+		</ul>
+	<h3>How to open a channel from Blixt towards Umbrel/home node</h3>
+		<ol>
+		<li>Activate Tor in Blixt - Settings - Tor onion. App will restart (if not, do it manually with force close).</li>
+		<li>Go to your Umbrel node and copy the onion URI of your Umbrel/home node, or just pull up the QR code for onion URI. it should be in this format `nodeID@onion-address:9735`</li>
+		<li>Go to Blixt - Settings - Lightning peers - add new peer</li>
+		<li>Scan QR code from your Umbrel/home node or paste the onion URI and your home node will be added as a peer.</li>
+		<li>Go back to Blixt main screen - top left drawer - Lightning channels.</li>
+		<li>Click on open new channel “+” sign and paste the onion URI or scan the QR code of your Umbrel node. Add amount of sats for the channel, fee and click open.</li>
+		<li>Done, channel will be open and functional after 3 block confirmations. Happy Lightning with your own Umbrel node!</li>
+		</ol>
+	<h3>How do I open a channel from my home node towards Blixt node?</h3>
+		<ol>
+		<li>Activate Tor in Blixt - Settings - Tor onion. App will restart (if not, do it manually with force close).</li>
+		<li>Wait for Blixt to open in Tor mode and sync the latest blocks (see the sync icon on top)</li>
+		<li>Go to Blixt settings - see “Show Tor onion service”, copy it, is your Blixt node URI. Is good to have it saved also in your password manager, for later usage.</li>
+		<li>Go to your Umbrel app RTL or Thunderhub (preferably) - add peer and paste your Blixt onion URI</li>
+		<li>Go to your Umbrel node dashboard or RTL/Thunderhub - open channel, and select known peer from list looking for your Blixt nodeID</li>
+		<li>Put the amount of sats for the channel, fees, click open. Wait for 3 block confirmations and you have a new channel with your "mini node" Blixt.</li>
+		<li>Optional, later when is ready active, you can push funds using keysend feature, into one side or another. Blixt also supports keysend, as Thunderhub too.</li>
+		</ol>
   </section>
 
-  <section>
-    <h2>How do I do that?</h2>
-    <p>That can be done doing that you to do this first and then you do that.</p>
-  </section>
 </article>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Frequently Asked Questions
+---
+<article class="faq">
+  <h1>Frequently Asked Questions</h1>
+
+  <section id="connect-full-node">
+    <h2>How do I connect Blixt Wallet to my own full node?</h2>
+    <p>Here follows pedagogic explanation from Darthcoin because my answer would just be "it's very simple".</p>
+    <p>One thing to note is that Blixt does not yet support <a href="https://github.com/lightningnetwork/lnd/issues/4973">Tor onion v3</a>.</p>
+  </section>
+
+  <section>
+    <h2>How do I remotely control an Umbrel?</h2>
+    <p><strong>Blixt Wallet</strong> is a fully fledged lightning node in of itself. Rather than controlling your full node at your home, enable to Tor and open a channel towards it.</p>
+  </section>
+
+  <section>
+    <h2>How do I do this?</h2>
+    <p>Some text explaining how to do that</p>
+  </section>
+
+  <section>
+    <h2>How do I do that?</h2>
+    <p>That can be done doing that you to do this first and then you do that.</p>
+  </section>
+</article>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: Home
 ---
+<article>
 {% include blixt-web.html %}
 <small><a href="https://github.com/BlixtWallet/blixtwallet.github.io/edit/master/index.html">Edit this page</a></small>
 <p>
@@ -41,7 +42,7 @@ title: Home
   With
   <a href="https://github.com/hsjoberg/dunder-lsp">Dunder LSP</a>,
   getting started is as easy as receiving a Lightning payment,
-  this Lightning Service Provider will create a channel automatically for you.
+  this Lightning Service Provider will open a channel automatically for you.
 </p>
 <h2>Feature-rich and cutting-edge</h2>
 <p>
@@ -73,3 +74,4 @@ title: Home
 <script>
 document.querySelector("#email").setAttribute("href", `${atob("bWFpbHRvOmhhbXB1cy5zam9iZXJnQHByb3Rvbm1haWwuY29t")}`);
 </script>
+</article>


### PR DESCRIPTION
---
layout: default
title: Frequently Asked Questions
---
<article class="faq">
  <h1>Frequently Asked Questions</h1>

  <section id="blixt-receive-funds">
    <h2>How do I receive funds (satoshis) into Blixt wallet?</h2>
    <p>This is an amazing simple experience to receive funds directly in your fresh open Blixt node wallet, no need to deposit funds and manually open channels with specific nodes.</p>
		<ol>
		<li>Once you create the wallet and save the seed, go to Blixt settings and activate "Dunder LSP".</li>
		<li>Go back to Blixt main screen - click on receive, put the amount, but no more than 400k sats (there's a limitation for now).</li>
		<li>It will create a LN invoice to be paid from another LN wallet.</li>
		<li>Once the LN invoice is paid, Dunder LSP service will create a channel of max 400k sats and push those funds you sent (200k sats for example) on your channel side. So you will have a nice channel ready to send 200k sats and receive 200k sats.</li>
		<li>If you will have another receiving payment to your Blixt, for less than 200k sats, it will be used the same channel. If the amount will be higher, Dunder will create a new channel (of max 400k sats). and so on with all your receiving payments.</li>
		</ol>
	<h3>IMPORTANT NOTE: get used to make backups of your LN channels every time you open/close a channel. Takes exactly few seconds to do it, even if for short time you store it on your own mobile memory. Later you can move it to your safe place storage. Also you can use Google Drive backup offered into Blixt. Don't be lazy and ignore this simple rule, it will save you later from much trouble.</h3>
  </section>
  
  <section id="blixt-node-address">
	<h2>How do I obtain/see my Blixt nodeID?</h2>
	<p>In order to be able to share or use your Blixt nodeID for opening channels, you need to activate it. But due to the fact that the Blixt node is a mobile one, so usually your mobile phone will have a different IP based on your location, will need to be used behind Tor network, so could have a static onion address.</p>
		<ul>
		<li>Go to Blixt - settings - activate Tor onion. app will restart (if not, do it manually)</li>
		<li>Wait for Blixt to connect to Tor and sync latest blocks and indexes (see the sync icon on top). Takes only few moments.</li>
		<li>Go to Blixt settings - under Tor onion, you have "show onion address" option. Now you can see the full node URI with a onion address. Save that for later use, by long press it, copy into clipboard and then save it in your safe places (eg. password manager).</li>
		</ul>
	</section>

  <section id="connect-full-node">
    <h2>How do I connect Blixt Wallet to my own full node (BIP157)?</h2>
    <p>One thing to note is that Blixt does not yet support <a href="https://github.com/lightningnetwork/lnd/issues/4973">Tor onion v3</a>.</p>
	<p>So for the moment, only if your home node is "visible" on clearnet (IP/domain) and have activated the SPV filters in bitcoin.conf. You can test it also using your node local IP when you connect your Blixt on the same LAN ((Wifi) as your home node.</p>
  </section>

  <section id="umbrel-control">
    <h2>How do I remotely control an Umbrel node?</h2>
    <p><strong>Blixt Wallet</strong> is a fully fledged lightning node in of itself. Rather than controlling your full node at your home, enable to Tor and open a channel towards it.</p>
	<p>Blixt node can be a really good "companion" for your home Umbrel node. Take this example:</p>
		<ul>
		<li>you have your Umbrel LN node with lots of channels open and do several routing. That's your main "bank" withg a lot of funds in it. Umbrel is your routing node.</li>
		<li>you have Blixt in your mobile phone, that can be your "node companion", with smaller amounts of satoshis. Blixt is your "spending" node, that need fast and cheap paths for quick spending. So connecting it with your Umbrel node, by opening a channel with it, you can move easy funds and use your Umbrel node as "frontend" sender.</li>
		<li>your Blixt mobile node also can connect to other nodes and Dunder LSP. That will bring you even more connectivity and options to move funds around, in a very easy and quick manner.</li>
		<li>you can have a Dunder LSP channel for incoming txs and a normal private channel with your home/Umbrel node for outgoing txs.</li>
		</ul>
  </section>

  <section id="umbrel-channel">
    <h2>How do I open a channel with my Umbrel/myNode/Raspiblitz/other node?</h2>
    <p>There are 2 options: opening from Blixt towards your node also from your node towards your Blixt node.</p>
	<p>But first let's mention some aspects to be taken in consideration:</p>
		<ul>
		<li>these channels open with your home node, will be private by default. That means you will not be able to route other txs through them. And are private for a reason: a mobile node is not supposed to be 100% all the time online, only when is needed to make a tx by the user.</li>
		<li>usually these channels are open using <a href="https://en.wikipedia.org/wiki/Tor_(network)">Tor network</a>, due to the fact that most of home nodes (Umbrel, myNode, Raspiblitz) are by default Tor enabled. So when you want to open/use these channels, be sure you activate Tor on your Blixt app.</li>
		<li>these channels are your first hop into a payment, so you can easily set 0 total fees and let your main home node to deal with the best following route.</li>
		</ul>
	<h3>How to open a channel from Blixt towards Umbrel/home node</h3>
		<ol>
		<li>Activate Tor in Blixt - Settings - Tor onion. App will restart (if not, do it manually with force close).</li>
		<li>Go to your Umbrel node and copy the onion URI of your Umbrel/home node, or just pull up the QR code for onion URI. it should be in this format `nodeID@onion-address:9735`</li>
		<li>Go to Blixt - Settings - Lightning peers - add new peer</li>
		<li>Scan QR code from your Umbrel/home node or paste the onion URI and your home node will be added as a peer.</li>
		<li>Go back to Blixt main screen - top left drawer - Lightning channels.</li>
		<li>Click on open new channel “+” sign and paste the onion URI or scan the QR code of your Umbrel node. Add amount of sats for the channel, fee and click open.</li>
		<li>Done, channel will be open and functional after 3 block confirmations. Happy Lightning with your own Umbrel node!</li>
		</ol>
	<h3>How do I open a channel from my home node towards Blixt node?</h3>
		<ol>
		<li>Activate Tor in Blixt - Settings - Tor onion. App will restart (if not, do it manually with force close).</li>
		<li>Wait for Blixt to open in Tor mode and sync the latest blocks (see the sync icon on top)</li>
		<li>Go to Blixt settings - see “Show Tor onion service”, copy it, is your Blixt node URI. Is good to have it saved also in your password manager, for later usage.</li>
		<li>Go to your Umbrel app RTL or Thunderhub (preferably) - add peer and paste your Blixt onion URI</li>
		<li>Go to your Umbrel node dashboard or RTL/Thunderhub - open channel, and select known peer from list looking for your Blixt nodeID</li>
		<li>Put the amount of sats for the channel, fees, click open. Wait for 3 block confirmations and you have a new channel with your "mini node" Blixt.</li>
		<li>Optional, later when is ready active, you can push funds using keysend feature, into one side or another. Blixt also supports keysend, as Thunderhub too.</li>
		</ol>
  </section>

</article>